### PR TITLE
Crashes when using non-rest controllers (like Hessian)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.kastkode</groupId>
   <artifactId>springsandwich</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>Annotation-based Controller Filtering for Spring Web</name>
   <url>http://springsandwich.com</url>
     <properties>


### PR DESCRIPTION
Our project uses a combination JSON API endpoints, served by normal controllers, and a RPC endpoint served by Hessian using a `HessianServiceExporter`.  When SpringSandwitch is included.  I get the following crash anytime the hessian endpoint is hit:

```
16:26:16 [http-nio-8080-exec-1] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.ClassCastException: org.springframework.remoting.caucho.HessianServiceExporter cannot be cast to org.springframework.web.method.HandlerMethod] with root cause
java.lang.ClassCastException: org.springframework.remoting.caucho.HessianServiceExporter cannot be cast to org.springframework.web.method.HandlerMethod
	at com.kastkode.springsandwich.filter.internal.InterceptDelegator.preHandle(InterceptDelegator.java:34)
	at org.springframework.web.servlet.HandlerExecutionChain.applyPreHandle(HandlerExecutionChain.java:134)
```

SpringSandwhich shouldn't process any controllers that aren't normal web controllers.  This patch causes it to ignore them.  

I also removed the `super` calls to `HandlerInterceptorAdapter` because they are no-ops in the parent class.